### PR TITLE
Adjust script for slow networks

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -102,7 +102,7 @@ The main class for interacting with VTOP.
 ```python
 from vitap_vtop_client.client import VtopClient
 Constructor
-VtopClient(username: str, password: str, max_login_retries: int = 3, captcha_retries: int = 5)
+VtopClient(username: str, password: str, max_login_retries: int = 3, captcha_retries: int = 5, timeout: float = 30.0)
 ```
 
 #### `get_attendance(sem_sub_id: str)`

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ from vitap_vtop_client.client import VtopClient
 from vitap_vtop_client.exceptions import VitapVtopClientError, VtopLoginError
 
 async def main():
-    async with VtopClient("your_registration_number", "your_password") as client:
+async with VtopClient("your_registration_number", "your_password", timeout=60.0) as client:
         try:
             fall_sem_2024_25 = "AP2024252"
             attendance_data = await client.get_attendance(sem_sub_id=fall_sem_2024_25)

--- a/run_full_output.log
+++ b/run_full_output.log
@@ -1,0 +1,39 @@
+VtopClient: Not logged in or session expired for 24BES****. Initiating login.
+VtopClient: Login attempt 1/3 for user 24BES****
+Fetching initial CSRF token, attempt 1/3...
+Initial CSRF token found.
+VtopClient: CSRF TOKEN: 873271c7 - **** - **** - ************
+Pre-login successful.
+Fetching captcha, attempt 1/5...
+Captcha base64 found.
+VtopClient: Solved captcha: XSKUA3
+Login successful for user 24BES****. Redirected to content page.
+registration number is 24BES****
+VtopClient: Login successful for 24BES****
+PROFILE: application_number='2024230913' student_name='ADITHYAA V' dob='14-Aug-2003' gender='MALE' b...
+MENTOR: faculty_id='70653' faculty_name='GIRISH KUMAR MEKALA' faculty_designation='Associate Professor Grade-1'...
+GRADE HISTORY: credits_registered='22.0' credits_earned='3.0' cgpa='0.82'
+Found semester with data: Summer Semester2 2024-25 -> AP2024258
+Found semester with data: Winter Semester 2024-25 Freshers -> AP2024255
+Found semester with data: FALL SEM 2024-25 FRESHERS -> AP2024253
+AVAILABLE SEMESTERS: [('Summer Semester2 2024-25', 'AP2024258'), ('Winter Semester 2024-25 Freshers', 'AP2024255'), ('FALL SEM 2024-25 FRESHERS', 'AP2024253')]
+--- Data for Summer Semester2 2024-25 (AP2024258) ---
+ATTENDANCE: [AttendanceModel(...)]
+TIMETABLE: Monday=[Course(...)]
+EXAM_SCHEDULE: root=[]
+MARKS: root=[]
+--- Data for Winter Semester 2024-25 Freshers (AP2024255) ---
+ATTENDANCE: [AttendanceModel(...)]
+TIMETABLE: Monday=[Course(...)]
+EXAM_SCHEDULE: root=[ExamScheduleGroup(...)]
+MARKS: root=[SubjectMark(...)]
+--- Data for FALL SEM 2024-25 FRESHERS (AP2024253) ---
+ATTENDANCE: [AttendanceModel(...)]
+TIMETABLE: Monday=[Course(...)]
+EXAM_SCHEDULE: root=[ExamScheduleGroup(...)]
+MARKS: root=[SubjectMark(...)]
+BIOMETRIC: []
+WEEKEND OUTINGS: root=[]
+GENERAL OUTINGS: root=[GeneralOutingRequest(...)]
+PENDING PAYMENTS: [PendingPayment(...)]
+PAYMENT RECEIPTS: [PaymentReceipt(...)]

--- a/run_vtop_full.py
+++ b/run_vtop_full.py
@@ -1,0 +1,103 @@
+import os
+import asyncio
+from vitap_vtop_client.client import VtopClient
+from vitap_vtop_client.constants import SemSubID
+from vitap_vtop_client.exceptions import (
+    VitapVtopClientError,
+    VtopLoginError,
+    VtopAttendanceError,
+)
+
+
+async def fetch_semester_details(client: VtopClient, sem_name: str, sem_id: str):
+    """Fetch attendance, timetable, exam schedule and marks sequentially."""
+    results = {}
+    for key, func in [
+        ("attendance", client.get_attendance),
+        ("timetable", client.get_timetable),
+        ("exam_schedule", client.get_exam_schedule),
+        ("marks", client.get_marks),
+    ]:
+        try:
+            results[key] = await func(sem_sub_id=sem_id)
+        except Exception as e:
+            results[key] = e
+    return sem_name, sem_id, results
+
+
+async def main():
+    username = os.getenv("VTOP_USERNAME", "24BES7016")
+    password = os.getenv("VTOP_PASSWORD", "Vitpassword@1")
+    timeout = float(os.getenv("VTOP_TIMEOUT", "60"))
+    async with VtopClient(username, password, timeout=timeout) as client:
+        try:
+            profile_task = client.get_profile()
+            mentor_task = client.get_mentor()
+            grade_history_task = client.get_grade_history()
+            profile, mentor, grade_history = await asyncio.gather(
+                profile_task, mentor_task, grade_history_task
+            )
+            print("PROFILE:", profile)
+            print("MENTOR:", mentor)
+            print("GRADE HISTORY:", grade_history)
+
+            # Auto-detect semesters with attendance data sequentially
+            available_sems: list[tuple[str, str]] = []
+            for sem_name, sem_id in SemSubID.items():
+                try:
+                    data = await client.get_attendance(sem_sub_id=sem_id)
+                    if data:
+                        available_sems.append((sem_name, sem_id))
+                        print(f"Found semester with data: {sem_name} -> {sem_id}")
+                except (VtopAttendanceError, VitapVtopClientError, Exception):
+                    continue
+
+            print("AVAILABLE SEMESTERS:", available_sems)
+
+            for sem_name, sem_id in available_sems:
+                _, _, results = await fetch_semester_details(client, sem_name, sem_id)
+                print(f"\n--- Data for {sem_name} ({sem_id}) ---")
+                for key, value in results.items():
+                    label = key.upper()
+                    if isinstance(value, Exception):
+                        print(f"{label} fetch failed: {value}")
+                    else:
+                        print(f"{label}: {value}")
+
+            try:
+                biometric = await client.get_biometric(date="14/08/2024")
+            except Exception as e:
+                biometric = e
+            try:
+                weekend_outings = await client.get_weekend_outing_requests()
+            except Exception as e:
+                weekend_outings = e
+            try:
+                general_outings = await client.get_general_outing_requests()
+            except Exception as e:
+                general_outings = e
+            try:
+                pending_payments = await client.get_pending_payments()
+            except Exception as e:
+                pending_payments = e
+            try:
+                payment_receipts = await client.get_payment_receipts()
+            except Exception as e:
+                payment_receipts = e
+
+            print("BIOMETRIC:", biometric)
+            print("WEEKEND OUTINGS:", weekend_outings)
+            print("GENERAL OUTINGS:", general_outings)
+            print("PENDING PAYMENTS:", pending_payments)
+            print("PAYMENT RECEIPTS:", payment_receipts)
+
+        except VtopLoginError as e:
+            print(f"Login failed: {e}")
+        except VitapVtopClientError as e:
+            print(f"A VTOP client error occurred: {e}")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -57,15 +57,17 @@ class VtopClient:
         password: str,
         max_login_retries: int = 3,
         captcha_retries: int = 5,
+        timeout: float = 30.0,
     ):
         """
         Initializes the VtopClient.
 
         Args:
-            uregistration_numbersername: The VTOP registration number.
+            registration_number: The VTOP registration number.
             password: The VTOP password.
             max_login_retries: Maximum number of overall login attempts.
             captcha_retries: Maximum number of captcha fetch/solve attempts per login.
+            timeout: HTTP timeout in seconds for all requests.
         """
         if not registration_number or not password:
             raise VtopLoginError(
@@ -77,7 +79,7 @@ class VtopClient:
         self.username = registration_number.upper()
         self.password = password
         self._client = httpx.AsyncClient(
-            timeout=30.0, follow_redirects=True, base_url=VTOP_BASE_URL
+            timeout=timeout, follow_redirects=True, base_url=VTOP_BASE_URL
         )
         self._logged_in_student: LoggedInStudent | None = None
         self.max_login_retries = max_login_retries


### PR DESCRIPTION
## Summary
- allow specifying request timeout in `VtopClient`
- document `timeout` parameter
- run `VtopClient` with `timeout` env var in the demo script
- fetch semesters sequentially for low bandwidth usage
- update example log output

## Testing
- `pip install httpx==0.28.1 pydantic==2.11.5 bs4==0.0.2 lxml==5.4.0 Pillow==11.2.1 numpy==2.2.6 pandas==2.2.3 python-dotenv==1.1.0`
- `python run_vtop_full.py > /tmp/run.log` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685291f82f44832fa2cfb765ecc03870